### PR TITLE
Feature: improve one time login functionality

### DIFF
--- a/web/modules/custom/nlc_prototype/src/Form/DirectoryTokenAccessForm.php
+++ b/web/modules/custom/nlc_prototype/src/Form/DirectoryTokenAccessForm.php
@@ -162,7 +162,7 @@ class DirectoryTokenAccessForm extends FormBase {
    * @return \Drupal\Core\GeneratedUrl|string
    */
   private function directoryUrl(User $account, $options = array()) {
-    $timestamp = REQUEST_TIME;
+    $timestamp = \Drupal::time()->getRequestTime();
     $langCode = isset($options['langcode']) ? $options['langcode'] : $account
       ->getPreferredLangcode();
 


### PR DESCRIPTION
Ok, so I think it’s working and it’s got the right balance now …

- you can use a one-time login link to login and create a session in a browser
- you can close that browser and re-open it and use the one-time login link again and it’ll
  1. register you still have a valid session and
  2. redirect you to the `/directory` page
- if you open a new different browser (e.g. different browser, or incognito window in same browser) without an active session and use the one-time login link it will see that you don’t have a session, so try to do the normal authentication on the link parameters and fail, as before.

And I think that’s the right behaviour, the right balance between security and usability.

I think it’s right coz the link comes in an email, and simply clicking on it will bring up the system default browser for the user, which should closely correlate to their last browser for the site.