### PR TITLE
Changes the anonymous user name Lewis Nyman > Dr Anonymous

### DIFF
--- a/config/sync/user.settings.yml
+++ b/config/sync/user.settings.yml
@@ -1,4 +1,4 @@
-anonymous: 'Lewis Nyman'
+anonymous: 'Dr Anonymous'
 verify_mail: true
 notify:
   cancel_confirm: true


### PR DESCRIPTION
[ch690]

Having the anonymous user as a real person, Lewis Nyman, is confusing in the logs.