### PR TITLE
Add drush commands to refresh access tokens

### DIFF
--- a/web/modules/custom/nlc_salesforce/drush.services.yml
+++ b/web/modules/custom/nlc_salesforce/drush.services.yml
@@ -1,0 +1,6 @@
+services:
+  nlc_salesforce.commands:
+    class: \Drupal\nlc_salesforce\Commands\NLCSalesforceCommands
+    arguments: ['@salesforce.client', '@entity_type.manager', '@plugin.manager.salesforce.auth_providers', '@salesforce.auth_token_storage']
+    tags:
+      - { name: drush.command }

--- a/web/modules/custom/nlc_salesforce/src/Commands/NLCSalesforceCommands.php
+++ b/web/modules/custom/nlc_salesforce/src/Commands/NLCSalesforceCommands.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Drupal\nlc_salesforce\Commands;
+
+use Consolidation\OutputFormatters\StructuredData\RowsOfFields;
+use Drupal\salesforce\Commands\SalesforceCommandsBase;
+use OAuth\OAuth2\Token\StdOAuth2Token;
+
+/**
+ * A Drush commandfile.
+ *
+ * In addition to this file, you need a drush.services.yml
+ * in root of your module, and a composer.json file that provides the name
+ * of the services file to use.
+ *
+ * See these files for an example of injecting Drupal services:
+ *   - http://cgit.drupalcode.org/devel/tree/src/Commands/DevelCommands.php
+ *   - http://cgit.drupalcode.org/devel/tree/drush.services.yml
+ */
+class NLCSalesforceCommands extends SalesforceCommandsBase {
+
+  /**
+   * Return list of authentication tokens.
+   *
+   * @command salesforce:list-providers
+   * @aliases nsflp
+   * @field-labels
+   *   default: Default
+   *   label: Label
+   *   name: Name
+   *   status: Token Status
+   * @default-fields label,name,default,status
+   *
+   * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields
+   *   The auth provider details.
+   */
+  public function listAuthProviders() {
+    $rows = [];
+    foreach($this->authMan->getProviders() as $provider) {
+
+      $rows[] = [
+        'default' => $this->authMan->getConfig()->id() == $provider->id() ? '✓' : '',
+        'label' => $provider->label(),
+        'name' => $provider->id(),
+        'status' => $provider->getPlugin()->hasAccessToken() ? 'Authorized' : 'Missing',
+      ];
+    }
+
+    return new RowsOfFields($rows);
+  }
+
+  /**
+   * Refresh the named authentication token.
+   *
+   * @param string $providerName
+   *   The name of the authentication provider.
+   *
+   * @command salesforce:refresh-token
+   * @aliases nsfrt
+   *
+   * @return \Consolidation\OutputFormatters\StructuredData\RowsOfFields|null
+   *   Describe result.
+   *
+   * @throws \OAuth\OAuth2\Service\Exception\MissingRefreshTokenException
+   */
+  public function refreshToken($providerName = '') {
+    // If no provider name given, use the default.
+    if (empty($providerName)) {
+      $providerName = $this->authMan->getConfig()->id();
+    }
+
+    foreach($this->authMan->getProviders() as $provider) {
+      if ($providerName == $provider->id()) {
+        $auth = $provider->getPlugin();
+        $token = $auth->hasAccessToken() ? $auth->getAccessToken() : new StdOAuth2Token();
+        $auth->refreshAccessToken($token);
+        return "Access token refreshed for $providerName";
+      }
+    }
+  }
+}


### PR DESCRIPTION
This adds two drush commands. One lists all token providers so you can see the status and machine name. It essentially reflects the admin page.

The other refreshes the access token of the named providers, if no name is provided on the command line it will refresh the default provider.

I've tested this by revoking the token on the admin page and refreshing from drush. I've also refreshed a valid token without issue and created a secondary provider to make sure the command picks the correct one.