### PR TITLE
Apply patch from d.org for salesforce commands

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -111,6 +111,9 @@
         "patches": {
             "drupal/core": {
                 "Notice: Undefined index: value in Drupal\\views\\Plugin\\views\\filter\\NumericFilter->acceptExposedInput()": "https://www.drupal.org/files/issues/2019-04-17/exposed-filter-notice-2825860-25.patch"
+            },
+            "drupal/salesforce": {
+                "Drush command to revoke and refresh authentication token": "https://www.drupal.org/files/issues/2019-12-19/3102133-drush-auth-tokens.patch"
             }
         }
     }


### PR DESCRIPTION
This PR supersedes the branch feature/salesforce_env which should be kept to maintain this code until the patch is accepted into the Salesforce module.

This is essentially the same work, with a revoke command added for completeness. The patch itself can be found at https://www.drupal.org/project/salesforce/issues/3102133