### PR TITLE
Feature/ch643/salesforce config split

### DIFF
--- a/config/crm_prod/.htaccess
+++ b/config/crm_prod/.htaccess
@@ -1,0 +1,27 @@
+# Deny all requests from Apache 2.4+.
+<IfModule mod_authz_core.c>
+  Require all denied
+</IfModule>
+
+# Deny all requests from Apache 2.0-2.2.
+<IfModule !mod_authz_core.c>
+  Deny from all
+</IfModule>
+
+# Turn off all options we don't need.
+Options -Indexes -ExecCGI -Includes -MultiViews
+
+# Set the catch-all handler to prevent scripts from being executed.
+SetHandler Drupal_Security_Do_Not_Remove_See_SA_2006_006
+<Files *>
+  # Override the handler again if we're run later in the evaluation list.
+  SetHandler Drupal_Security_Do_Not_Remove_See_SA_2013_003
+</Files>
+
+# If we know how to do it safely, disable the PHP engine entirely.
+<IfModule mod_php5.c>
+  php_flag engine off
+</IfModule>
+<IfModule mod_php7.c>
+  php_flag engine off
+</IfModule>

--- a/config/crm_prod/salesforce.salesforce_auth.salesforce_auth.yml
+++ b/config/crm_prod/salesforce.salesforce_auth.salesforce_auth.yml
@@ -1,0 +1,16 @@
+uuid: cc9e3ff5-14f7-471f-accb-94bd70ef9048
+langcode: en
+status: true
+dependencies:
+  config:
+    - key.key.salesforce_pem
+  module:
+    - salesforce_jwt
+id: salesforce_auth
+label: 'Salesforce Auth'
+provider: jwt
+provider_settings:
+  consumer_key: dummy_key
+  login_user: user@example.com
+  login_url: 'https://salesforce.com'
+  encrypt_key: salesforce_pem

--- a/config/crm_prod/salesforce.settings.yml
+++ b/config/crm_prod/salesforce.settings.yml
@@ -1,0 +1,1 @@
+salesforce_auth_provider: salesforce_auth

--- a/config/sync/config_split.config_split.crm_prod.yml
+++ b/config/sync/config_split.config_split.crm_prod.yml
@@ -1,0 +1,17 @@
+uuid: 3105046a-1e8e-47b6-9cf9-5870e514e66e
+langcode: en
+status: false
+dependencies: {  }
+id: crm_prod
+label: 'CRM Production'
+description: 'Salesforce settings for the production server.'
+folder: ../config/crm_prod
+module: {  }
+theme: {  }
+blacklist:
+  - salesforce.salesforce_auth.salesforce_auth
+  - salesforce.settings
+graylist: {  }
+graylist_dependents: true
+graylist_skip_equal: true
+weight: 0

--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -789,6 +789,12 @@ if (getenv('NLC_ENVIRONMENT')) {
 if (getenv('SALESFORCE_PEM_PATH')) {
   $config['key.key.salesforce_pem']['key_provider_settings']['file_location'] = getenv('SALESFORCE_PEM_PATH');
 }
-$config['salesforce.salesforce_auth.salesforce_auth']['provider_settings']['consumer_key'] = getenv('SALESFORCE_KEY');
-$config['salesforce.salesforce_auth.salesforce_auth']['provider_settings']['login_user'] = getenv('SALESFORCE_LOGIN');
-$config['salesforce.salesforce_auth.salesforce_auth']['provider_settings']['login_url'] = getenv('SALESFORCE_URL');
+if (getenv('SALESFORCE_KEY')) {
+  $config['salesforce.salesforce_auth.salesforce_auth']['provider_settings']['consumer_key'] = getenv('SALESFORCE_KEY');
+}
+if (getenv('SALESFORCE_LOGIN')) {
+  $config['salesforce.salesforce_auth.salesforce_auth']['provider_settings']['login_user'] = getenv('SALESFORCE_LOGIN');
+}
+if (getenv('SALESFORCE_URL')) {
+  $config['salesforce.salesforce_auth.salesforce_auth']['provider_settings']['login_url'] = getenv('SALESFORCE_URL');
+}

--- a/web/sites/default/settings.prod-eks.php
+++ b/web/sites/default/settings.prod-eks.php
@@ -30,4 +30,5 @@ $config['sendgrid_integration.settings']['apikey'] = getenv('CONNECT_SENDGRID_AP
 
 // Ensure the devel config environment is off
 $config['config_split.config_split.devel']['status'] = FALSE;
+$config['config_split.config_split.crm_prod']['status'] = TRUE;
 


### PR DESCRIPTION
New crm_prod configuration is disabled by default so it will be ignored in future. This will prevent devs accidentally adding anything sensitive.

It's then explicitly enabled in production so the dummy settings are created so they can subsequently be overridden by environment variables.