### PR TITLE
Bind the new Elasticsearch backing service to the application in PaaS [ch1185]

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -8,6 +8,7 @@ applications:
   services:
     - nlc-alpha-s3
     - nlc-alpha-drupal-mysql
+    - nlc-alpha-drupal-elastic
 - name: nlc-alpha-drupal-cron
   path: ./app_cron
   memory: 24M


### PR DESCRIPTION
This PR binds the new Elasticsearch backing service to the  `nlc-alpha-drupal` app in PaaS CloudFoundry.

See documentation on binding the ES backing service at. https://docs.cloud.service.gov.uk/deploying_services/elasticsearch/#bind-an-elasticsearch-service-to-your-apps

Service was set up using the how-to at https://docs.cloud.service.gov.uk/deploying_services/elasticsearch/#set-up-an-elasticsearch-service

The service was created successfully:

```
$ cf service nlc-alpha-drupal-elastic

Showing info of service nlc-alpha-drupal-elastic in org cabinet-office-national-leadership-centre / space nlc-alpha-drupal as joe.baker@weareconvivio.com...

name:             nlc-alpha-drupal-elastic
service:          elasticsearch
tags:             
plan:             small-ha-6.x
description:      Elasticsearch instances provisioned via Aiven
documentation:    
dashboard:        
service broker:   aiven-broker

Showing status of last operation from service nlc-alpha-drupal-elastic...

status:    create succeeded
message:   Last operation succeeded
started:   2020-01-24T11:15:37Z
updated:   2020-01-24T11:22:58Z

There are no bound apps for this service.
```

This makes it possible to merge #88 to master and deploy to PaaS prior to the NLF event (but not today!)

By merging this branch and deploying this small change, we can bind the backing service to the app and ensure that any connection variables are in the PaaS app environment prior to deploying #88.