### PR TITLE
Hide the RYI banner block if registered [ch1658]

### DIFF
--- a/web/modules/custom/nlc_register_interest/src/Plugin/Block/RegisterInterestBlock.php
+++ b/web/modules/custom/nlc_register_interest/src/Plugin/Block/RegisterInterestBlock.php
@@ -33,12 +33,19 @@ class RegisterInterestBlock extends BlockBase {
    * Control access to this block
    */
   protected function blockAccess(AccountInterface $account) {
-    if ($account->id() == 0) {
-      // Don't show to anonymous.
+    if ($account->id() == 0 || $account->id() == 1) {
+      // Don't show to anonymous or admin user, uid = 1.
       return AccessResult::forbidden();
     }
-    // Check for existing cohort.
+    /** @var \Drupal\user\UserInterface $user */
     $user = User::load($account->id());
+    // Check if register interest is empty.
+    $regEmpty = $user->get('field_register_interest')->value;
+    if (!empty($regEmpty)) {
+      return AccessResult::forbidden();
+    }
+
+    // Check for existing cohort.
     $cohortEmpty = $user->get('field_cohort')->isEmpty();
 
     return $cohortEmpty ? AccessResult::allowed() : AccessResult::forbidden();


### PR DESCRIPTION
This is just about block visibility — don't need to worry about the confirm form not being shown, coz form refresh happens with AJAX, so never re-examines block visibility.

[ch1658]