### PR TITLE
GA on PaaS staging is using the GA account ID for live, skewing GA data [ch1676]

### DIFF
--- a/config/crm_stage/google_analytics.settings.yml
+++ b/config/crm_stage/google_analytics.settings.yml
@@ -1,0 +1,42 @@
+account: UA-69921843-12
+premium: false
+domain_mode: 1
+cross_domains: ''
+visibility:
+  request_path_mode: 0
+  request_path_pages: "/admin\r\n/admin/*\r\n/batch\r\n/node/add*\r\n/node/*/*\r\n/user/*/*"
+  user_role_mode: 1
+  user_role_roles:
+    nlc_staff: nlc_staff
+    admin: admin
+  user_account_mode: 0
+track:
+  outbound: true
+  mailto: false
+  files: true
+  files_extensions: '7z|aac|arc|arj|asf|asx|avi|bin|csv|doc(x|m)?|dot(x|m)?|exe|flv|gif|gz|gzip|hqx|jar|jpe?g|js|mp(2|3|4|e?g)|mov(ie)?|msi|msp|pdf|phps|png|ppt(x|m)?|pot(x|m)?|pps(x|m)?|ppam|sld(x|m)?|thmx|qtm?|ra(m|r)?|sea|sit|tar|tgz|torrent|txt|wav|wma|wmv|wpd|xls(x|m|b)?|xlt(x|m)|xlam|xml|z|zip'
+  colorbox: true
+  linkid: false
+  urlfragments: false
+  userid: false
+  messages:
+    status: status
+    warning: warning
+    error: error
+  site_search: false
+  adsense: false
+  displayfeatures: true
+privacy:
+  anonymizeip: true
+custom:
+  dimension: {  }
+  metric: {  }
+codesnippet:
+  create: {  }
+  before: "(function(){\r\n    // Get a query string value, to track what is being search for\r\n    function getParameterByName(name) {\r\n        name = name.replace(/[\\[]/, \"\\\\[\").replace(/[\\]]/, \"\\\\]\");\r\n        var regex = new RegExp(\"[\\\\?&]\" + name + \"=([^&#]*)\"),\r\n        results = regex.exec(location.search);\r\n        return results === null ? \"\" : decodeURIComponent(results[1].replace(/\\+/g, \" \"));\r\n    };\r\n\r\n    window.onload = function(){\r\n        if(document.querySelector('h3.search-no-results') != null &&\r\n            document.querySelector('h3.search-no-results').innerText === \"Oops!\"){\r\n            var searchQuery = getParameterByName('search');\r\n            ga('send', 'event', 'Search','ZeroResults', searchQuery  ? searchQuery : 'Blank');\r\n        }\r\n    };\r\n\r\n})();"
+  after: ''
+translation_set: false
+cache: false
+debug: false
+_core:
+  default_config_hash: Vx5EGxHruJuiMSwDv8Mg3PBf9RaPo8o2MCj8_QeTUhg

--- a/config/sync/config_split.config_split.crm_stage.yml
+++ b/config/sync/config_split.config_split.crm_stage.yml
@@ -11,7 +11,8 @@ theme: {  }
 blacklist:
   - salesforce.salesforce_auth.salesforce_auth
   - salesforce.settings
-graylist: {  }
+graylist:
+  - google_analytics.settings
 graylist_dependents: true
 graylist_skip_equal: true
 weight: 0


### PR DESCRIPTION
Story details: https://app.clubhouse.io/nationalleadershipcentre/story/1676

This PR essentially just copies the `google_analytics.settings.yml` file from `config/devel` and then adapts the `crm_stage` config split to use this – since that config split is active on PaaS staging, seemed to make sense to use that rather than create a distinct split config just for this.