### PR TITLE
move docker base build to nlcdigital repo

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,5 +1,4 @@
-FROM subatomic/base-php-72-image 
-# TODO - move to NLC docker hub
+FROM nlcdigital/base-php-72-image 
 RUN mkdir -p /var/www/web/
 RUN mkdir -p /var/www/vendor/
 RUN mkdir -p /var/www/config/


### PR DESCRIPTION
Allowing us to remove the workaround in concourse that effectively does this same change from old to right repo in docker hub