### PR TITLE
Send supplied invalid email to Watchdog [ch2421]

### DIFF
--- a/web/modules/custom/nlc_prototype/src/Form/DirectoryTokenAccessForm.php
+++ b/web/modules/custom/nlc_prototype/src/Form/DirectoryTokenAccessForm.php
@@ -114,7 +114,8 @@ class DirectoryTokenAccessForm extends FormBase {
       $url = Url::fromUri('mailto:' . $email);
       $link = Link::fromTextAndUrl($email, $url);
       $form_state->setError($form, $this->t('Your email address does not currently have access to the directory. Please check your email address is correct. If it is, please contact @email for more information.', ['@email' => $link->toString()]));
-      \Drupal::logger('nlc_prototype')->error("Login failed: Unknown address $email");
+      $message = $this->t('Login failed: Unknown address @email', ['@email' => $form_state->getValue('email')]);
+      \Drupal::logger('nlc_prototype')->error($message);
     }
   }
 


### PR DESCRIPTION
Now, supplying an invalid email:

<img width="1044" alt="Screenshot 2020-02-20 at 13 52 34" src="https://user-images.githubusercontent.com/518081/74939842-75acd300-53e8-11ea-870c-a5532c0d4685.png">

adds the supplied email to the Watchdog log:

<img width="656" alt="Screenshot 2020-02-20 at 13 52 23" src="https://user-images.githubusercontent.com/518081/74939885-80fffe80-53e8-11ea-9a17-e11496a561fa.png">
