### PR TITLE
Remove banner when it's closed

### DIFF
--- a/web/themes/custom/bevan/js/behaviours.js
+++ b/web/themes/custom/bevan/js/behaviours.js
@@ -6,7 +6,15 @@
     attach: function (context, settings) {
       $('.eu-cookie-compliance__close').click(function() {
         Drupal.eu_cookie_compliance.toggleWithdrawBanner();
+        $('.eu-cookie-compliance-banner').trigger('eu_cookie_compliance_popup_close');
       });
+
+      $('.eu-cookie-compliance-banner').on('eu_cookie_compliance_popup_close', function() {
+        var wrapper = this.parentElement;
+        window.setTimeout(function() {
+          $(wrapper).remove();
+        }, drupalSettings.eu_cookie_compliance.popup_delay);
+      })
 
       // Track facet clicks so we can restore focus.
       $('.facet-item a').click(function(ev) {


### PR DESCRIPTION
Other parts of the cookie JS code trigger an event when the banner is closed so I've triggered it from the close button and then handled it. This was the removal code will pick up a close even no matter where it comes from.

The use if jQuery .remove instead of the vanilla JS allows the code to handle NULLs properly. If the banner is already removed, the remove() call will do nothing and not cause an error.