### PR TITLE
Switch on prod SF config, which is overridden in situ [ch1996]

### DIFF
--- a/web/sites/default/settings.staging-eks.php
+++ b/web/sites/default/settings.staging-eks.php
@@ -33,7 +33,7 @@ $config['sendgrid_integration.settings']['apikey'] = getenv('SENDGRID_API_KEY');
 $config['config_split.config_split.devel']['status'] = FALSE;
 // Ensure the correct CRM config environment is active
 $config['config_split.config_split.crm']['status'] = FALSE;
-$config['config_split.config_split.crm_prod']['status'] = FALSE;
+$config['config_split.config_split.crm_prod']['status'] = TRUE;
 $config['config_split.config_split.crm_stage']['status'] = TRUE;
 
 $settings['trusted_host_patterns'] = array('^staging\.connect\.nationalleadership\.gov\.uk$');


### PR DESCRIPTION
This still needs

```php
$config['config_split.config_split.crm_stage']['status'] = TRUE;
```

coz there's a Google Analytics file that we need there.