### PR TITLE
Feature: track User-ID and role in GA [ch2420]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -122,6 +122,9 @@
         "patches": {
             "drupal/core": {
                 "Notice: Undefined index: value in Drupal\\views\\Plugin\\views\\filter\\NumericFilter->acceptExposedInput()": "https://www.drupal.org/files/issues/2019-04-17/exposed-filter-notice-2825860-25.patch"
+            },
+            "drupal/google_analytics": {
+                "Allow event arguments in page attachments to be altered before being encoded to JSON": "https://www.drupal.org/files/issues/2020-03-02/ga-alter-event-arguments-in-page-attachments-3117147-01.patch"
             }
         }
     }

--- a/config/crm_stage/google_analytics.settings.yml
+++ b/config/crm_stage/google_analytics.settings.yml
@@ -27,7 +27,11 @@ track:
 privacy:
   anonymizeip: true
 custom:
-  dimension: {  }
+  dimension:
+    1:
+      name: 'User roles'
+      value: '[current-user:roles]'
+      index: 1
   metric: {  }
 codesnippet:
   create: {  }

--- a/config/crm_stage/google_analytics.settings.yml
+++ b/config/crm_stage/google_analytics.settings.yml
@@ -6,9 +6,7 @@ visibility:
   request_path_mode: 0
   request_path_pages: "/admin\r\n/admin/*\r\n/batch\r\n/node/add*\r\n/node/*/*\r\n/user/*/*"
   user_role_mode: 1
-  user_role_roles:
-    nlc_staff: nlc_staff
-    admin: admin
+  user_role_roles: {  }
   user_account_mode: 0
 track:
   outbound: true
@@ -18,7 +16,7 @@ track:
   colorbox: true
   linkid: false
   urlfragments: false
-  userid: false
+  userid: true
   messages:
     status: status
     warning: warning

--- a/config/devel/google_analytics.settings.yml
+++ b/config/devel/google_analytics.settings.yml
@@ -27,7 +27,11 @@ track:
 privacy:
   anonymizeip: true
 custom:
-  dimension: {  }
+  dimension:
+    1:
+      name: 'User roles'
+      value: '[current-user:roles]'
+      index: 1
   metric: {  }
 codesnippet:
   create: {  }

--- a/config/devel/google_analytics.settings.yml
+++ b/config/devel/google_analytics.settings.yml
@@ -6,9 +6,7 @@ visibility:
   request_path_mode: 0
   request_path_pages: "/admin\r\n/admin/*\r\n/batch\r\n/node/add*\r\n/node/*/*\r\n/user/*/*"
   user_role_mode: 1
-  user_role_roles:
-    nlc_staff: nlc_staff
-    admin: admin
+  user_role_roles: {  }
   user_account_mode: 0
 track:
   outbound: true
@@ -18,7 +16,7 @@ track:
   colorbox: true
   linkid: false
   urlfragments: false
-  userid: false
+  userid: true
   messages:
     status: status
     warning: warning

--- a/config/sync/google_analytics.settings.yml
+++ b/config/sync/google_analytics.settings.yml
@@ -29,7 +29,11 @@ track:
 privacy:
   anonymizeip: true
 custom:
-  dimension: {  }
+  dimension:
+    1:
+      name: 'User roles'
+      value: '[current-user:roles]'
+      index: 1
   metric: {  }
 codesnippet:
   create: {  }

--- a/web/modules/custom/nlc_prototype/nlc_prototype.module
+++ b/web/modules/custom/nlc_prototype/nlc_prototype.module
@@ -78,3 +78,22 @@ function nlc_prototype_search_api_query_alter(QueryInterface &$query) {
     }
   }
 }
+
+/**
+ * @param array $arguments
+ * @param \Drupal\Core\Session\AccountProxyInterface $account
+ */
+function nlc_prototype_google_analytics_event_arguments_alter(&$arguments, &$account) {
+  if (isset($arguments['user_id'])) {
+    /** @var \Drupal\nlc_prototype\SalesforceMapping\NetworkIndividualMapping $account_sf_mappings */
+    $account_sf_mappings = \Drupal::service('nlc_prototype.sf_mapping.network_individual');
+    try {
+      if ($account_sf_object = $account_sf_mappings->getAccountSfMappedObject()) {
+        $arguments['user_id'] = google_analytics_user_id_hash($account_sf_object->sfid());
+      }
+    }
+    catch (Exception $e) {
+      // Do nothing here.
+    }
+  }
+}

--- a/web/modules/custom/nlc_prototype/nlc_prototype.services.yml
+++ b/web/modules/custom/nlc_prototype/nlc_prototype.services.yml
@@ -1,0 +1,4 @@
+services:
+  nlc_prototype.sf_mapping.network_individual:
+    class: '\Drupal\nlc_prototype\SalesforceMapping\NetworkIndividualMapping'
+    arguments: ['@current_user']

--- a/web/modules/custom/nlc_prototype/src/SalesforceMapping/NetworkIndividualMapping.php
+++ b/web/modules/custom/nlc_prototype/src/SalesforceMapping/NetworkIndividualMapping.php
@@ -47,7 +47,7 @@ class NetworkIndividualMapping {
       // product variations that are not being managed by the SFDC integration. If
       // this is the case, we do not want to be programmatically manipulating these
       // objects.
-      if ($sfEntity->getEntityTypeId() == 'salesforce_mapped_object') {
+      if (is_object($sfEntity) && $sfEntity->getEntityTypeId() == 'salesforce_mapped_object') {
         return $sfEntity;
       }
     }

--- a/web/modules/custom/nlc_prototype/src/SalesforceMapping/NetworkIndividualMapping.php
+++ b/web/modules/custom/nlc_prototype/src/SalesforceMapping/NetworkIndividualMapping.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Drupal\nlc_prototype\SalesforceMapping;
+
+use Drupal\Core\Session\AccountProxyInterface;
+
+class NetworkIndividualMapping {
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
+   * @var AccountProxyInterface
+   */
+  protected $account;
+
+  public function __construct(AccountProxyInterface $account) {
+    // Use the full current user.
+    $this->account = \Drupal\user\Entity\User::load($account->id());;
+  }
+
+  /**
+   * @return \Drupal\salesforce_mapping\Entity\MappedObjectInterface|boolean
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  public function getAccountSfMappedObject() {
+    /** @var \Drupal\salesforce_mapping\MappedObjectStorage $mapped_object_storage */
+    $mapped_object_storage = &drupal_static(__FUNCTION__);
+
+    if (!isset($mapped_object_storage)) {
+      $mapped_object_storage = \Drupal::service('entity_type.manager')
+        ->getStorage('salesforce_mapped_object');
+    }
+
+    $sfEntityObjects = $this->getMappedSfObjects();
+    if (is_array($sfEntityObjects)) {
+      $sfEntity = current($sfEntityObjects);
+      // We're performing a check to see if we're dealing with a Salesforce Mapped
+      // Object.  The reason we do this instead of just checking to see if we're
+      // dealing with a Commerce Product Variation is that we could very well have
+      // product variations that are not being managed by the SFDC integration. If
+      // this is the case, we do not want to be programmatically manipulating these
+      // objects.
+      if ($sfEntity->getEntityTypeId() == 'salesforce_mapped_object') {
+        return $sfEntity;
+      }
+    }
+    return FALSE;
+  }
+
+  /**
+   * Helper function to fetch existing MappedObject or create a new one.
+   *
+   * @return \Drupal\salesforce_mapping\Entity\MappedObject[]
+   *   The Mapped Objects corresponding to the given entity.
+   *
+   * @throws \Drupal\Component\Plugin\Exception\InvalidPluginDefinitionException
+   * @throws \Drupal\Component\Plugin\Exception\PluginNotFoundException
+   */
+  private function getMappedSfObjects() {
+    // @TODO this probably belongs in a service
+    return $this
+      ->entityTypeManager()
+      ->getStorage('salesforce_mapped_object')
+      ->loadByEntity($this->account);
+  }
+
+  /**
+   * Retrieves the entity type manager.
+   *
+   * @return \Drupal\Core\Entity\EntityTypeManagerInterface
+   *   The entity type manager.
+   */
+  protected function entityTypeManager() {
+    if (!isset($this->entityTypeManager)) {
+      $this->entityTypeManager = $this->container()->get('entity_type.manager');
+    }
+    return $this->entityTypeManager;
+  }
+
+  /**
+   * Returns the service container.
+   *
+   * This method is marked private to prevent sub-classes from retrieving
+   * services from the container through it. Instead,
+   * \Drupal\Core\DependencyInjection\ContainerInjectionInterface should be used
+   * for injecting services.
+   *
+   * @return \Symfony\Component\DependencyInjection\ContainerInterface
+   *   The service container.
+   */
+  private function container() {
+    return \Drupal::getContainer();
+  }
+}


### PR DESCRIPTION
Uses the Salesforce ID to ensure consistency across all (potential future) systems, regardless of the Connect user's Drupal user ID or the state of the Drupal DB