### PR TITLE
New patch for salesforce to properly fix (?) SF token refresh [ch1996]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -128,7 +128,7 @@
                 "Allow event arguments in page attachments to be altered before being encoded to JSON": "https://www.drupal.org/files/issues/2020-03-02/ga-alter-event-arguments-in-page-attachments-3117147-01.patch"
             },
             "drupal/salesforce": {
-                "Refresh SF auth token drush command should also store the identity on first token request": "https://www.drupal.org/files/issues/2020-03-16/sf-refresh-auth-token-get-identity-also-3120102-2.patch"
+                "Refresh SF auth token drush command should also store the identity on first token request": "https://www.drupal.org/files/issues/2020-03-25/sf-refresh-auth-token-get-identity-also-3120102-4.patch"
             }
         }
     }


### PR DESCRIPTION
The previous patch was missing one key line, causing our problems.

Missing:

```php
use Drupal\Core\Form\FormState;
```

Doh.
