### PR TITLE
Feature: update link for survey in Connect with admin config form [ch3555]

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "drupal/bootstrap_barrio": "^4.22",
         "drupal/coder": "^8.3",
         "drupal/collapsiblock": "^2.0",
-        "drupal/config_filter": "2.x-dev",
+        "drupal/config_ignore": "^2.2",
         "drupal/config_split": "^1.4",
         "drupal/console": "^1.0.2",
         "drupal/core-composer-scaffold": "^8.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "63e6cf8f41f802228c63522aa726b0ae",
+    "content-hash": "f47e99a06250c23b2e8dc8e06bd4e608",
     "packages": [
         {
             "name": "alchemy/zippy",
@@ -2336,14 +2336,20 @@
         },
         {
             "name": "drupal/config_filter",
-            "version": "dev-2.x",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://git.drupalcode.org/project/config_filter.git",
-                "reference": "6d0d8021c8b74cff486a11ef785d3dfe7e0852d1"
+                "reference": "8.x-1.5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_filter-8.x-1.5.zip",
+                "reference": "8.x-1.5",
+                "shasum": "81210684c378dab856b3c2bce5eeaa58992d2efc"
             },
             "require": {
-                "drupal/core": "^8.8 || ^9"
+                "drupal/core": "^8 || ^9"
             },
             "suggest": {
                 "drupal/config_split": "Split site configuration for different environments."
@@ -2351,14 +2357,14 @@
             "type": "drupal-module",
             "extra": {
                 "branch-alias": {
-                    "dev-2.x": "2.x-dev"
+                    "dev-1.x": "1.x-dev"
                 },
                 "drupal": {
-                    "version": "8.x-2.0-rc1+0-dev",
-                    "datestamp": "1572541985",
+                    "version": "8.x-1.5",
+                    "datestamp": "1572542288",
                     "security-coverage": {
-                        "status": "not-covered",
-                        "message": "Dev releases are not covered by Drupal security advisories."
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
                     }
                 }
             },
@@ -2395,8 +2401,68 @@
                 "source": "http://cgit.drupalcode.org/config_filter",
                 "issues": "https://www.drupal.org/project/issues/config_filter",
                 "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
+        },
+        {
+            "name": "drupal/config_ignore",
+            "version": "2.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://git.drupalcode.org/project/config_ignore.git",
+                "reference": "8.x-2.2"
             },
-            "time": "2019-10-31T17:09:01+00:00"
+            "dist": {
+                "type": "zip",
+                "url": "https://ftp.drupal.org/files/projects/config_ignore-8.x-2.2.zip",
+                "reference": "8.x-2.2",
+                "shasum": "18af5772087b90dd4b83c2c6e292d8ea2f8834e0"
+            },
+            "require": {
+                "drupal/config_filter": "1.*",
+                "drupal/core": "~8.0"
+            },
+            "type": "drupal-module",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                },
+                "drupal": {
+                    "version": "8.x-2.2",
+                    "datestamp": "1576528386",
+                    "security-coverage": {
+                        "status": "covered",
+                        "message": "Covered by Drupal's security advisory policy"
+                    }
+                }
+            },
+            "notification-url": "https://packages.drupal.org/8/downloads",
+            "license": [
+                "GPL-2.0+"
+            ],
+            "authors": [
+                {
+                    "name": "Tommy Lynge Jørgensen",
+                    "homepage": "https://www.drupal.org/u/tlyngej",
+                    "email": "tlyngej@gmail.com",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "Fabian Bircher",
+                    "homepage": "https://www.drupal.org/u/bircher",
+                    "role": "Maintainer"
+                },
+                {
+                    "name": "tlyngej",
+                    "homepage": "https://www.drupal.org/user/413139"
+                }
+            ],
+            "description": "Ignore certain configuration during import.",
+            "homepage": "http://drupal.org/project/config_ignore",
+            "support": {
+                "source": "http://cgit.drupalcode.org/config_ignore",
+                "issues": "http://drupal.org/project/config_ignore",
+                "irc": "irc://irc.freenode.org/drupal-contribute"
+            }
         },
         {
             "name": "drupal/config_split",
@@ -6107,6 +6173,7 @@
                     "email": "jakub.onderka@gmail.com"
                 }
             ],
+            "abandoned": "php-parallel-lint/php-console-color",
             "time": "2018-09-29T17:23:10+00:00"
         },
         {
@@ -6153,6 +6220,7 @@
                 }
             ],
             "description": "Highlight PHP code in terminal",
+            "abandoned": "php-parallel-lint/php-console-highlighter",
             "time": "2018-09-29T18:48:56+00:00"
         },
         {
@@ -12261,7 +12329,6 @@
     "stability-flags": {
         "drupal/auto_entitylabel": 10,
         "drupal/better_exposed_filters": 15,
-        "drupal/config_filter": 20,
         "drupal/elasticsearch_connector": 15,
         "drupal/email_registration": 5,
         "drupal/encrypt": 5,

--- a/config/sync/config_ignore.settings.yml
+++ b/config/sync/config_ignore.settings.yml
@@ -1,0 +1,4 @@
+ignored_config_entities:
+  - nlc_prototype.config_covid19.settings
+_core:
+  default_config_hash: UVH1aJ4b44UM-VdPVN7hNNuuVqfReJxwfVeDQH1Hvsk

--- a/config/sync/core.extension.yml
+++ b/config/sync/core.extension.yml
@@ -11,6 +11,7 @@ module:
   comment: 0
   config: 0
   config_filter: 0
+  config_ignore: 0
   config_split: 0
   contextual: 0
   datetime: 0

--- a/config/sync/nlc_prototype.config_covid19.settings.yml
+++ b/config/sync/nlc_prototype.config_covid19.settings.yml
@@ -1,0 +1,2 @@
+covid19:
+  survey_url: 'https://www.smartsurvey.co.uk/s/CV19_Response_140420/'

--- a/web/modules/custom/nlc_prototype/nlc_prototype.links.menu.yml
+++ b/web/modules/custom/nlc_prototype/nlc_prototype.links.menu.yml
@@ -1,0 +1,12 @@
+nlc_prototype.admin_config_connect:
+  title: 'Connect admin'
+  description: 'Administer the Connect configurations'
+  parent: system.admin_config
+  route_name: nlc_prototype.admin_config_connect
+  weight: 50
+
+nlc_prototype.admin_config_connect_covid19:
+  title: 'Connect COVID-19 response admin'
+  description: 'Administer the Connect COVID-19 response configurations'
+  parent: nlc_prototype.admin_config_connect
+  route_name: nlc_prototype.admin_config_connect_covid19

--- a/web/modules/custom/nlc_prototype/nlc_prototype.permissions.yml
+++ b/web/modules/custom/nlc_prototype/nlc_prototype.permissions.yml
@@ -1,0 +1,6 @@
+'administer connect config':
+  title: 'Administer Connect configurations'
+  description: 'Administer configurations specific to the Connect customisations'
+'administer connect covid19 config':
+  title: 'Administer Connect COVID-19 configurations'
+  description: 'Administer configurations specific to the COVID-19 response tools'

--- a/web/modules/custom/nlc_prototype/nlc_prototype.routing.yml
+++ b/web/modules/custom/nlc_prototype/nlc_prototype.routing.yml
@@ -47,3 +47,20 @@ nlc_prototype.directory.token_access.login:
   options:
     _maintenance_access: TRUE
     no_cache: TRUE
+
+nlc_prototype.admin_config_connect:
+  path: '/admin/config/connect'
+  defaults:
+    _controller: '\Drupal\system\Controller\SystemController::systemAdminMenuBlockPage'
+    _title: 'Connect'
+    _description: 'Manage settings for Connect.'
+  requirements:
+    _permission: 'administer connect config'
+
+nlc_prototype.admin_config_connect_covid19:
+  path: '/admin/config/connect/covid19'
+  defaults:
+    _title: 'COVID-19 response admin'
+    _form: 'Drupal\nlc_prototype\Form\Covid19ConfigAdminForm'
+  requirements:
+    _permission: 'administer connect covid19 config'

--- a/web/modules/custom/nlc_prototype/src/Form/Covid19ConfigAdminForm.php
+++ b/web/modules/custom/nlc_prototype/src/Form/Covid19ConfigAdminForm.php
@@ -1,0 +1,63 @@
+<?php
+
+
+namespace Drupal\nlc_prototype\Form;
+
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+
+class Covid19ConfigAdminForm extends ConfigFormBase {
+
+  /**
+   * {@inheritDoc}
+   */
+  public function getFormId() {
+    return 'connect_covid19_admin_form';
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    // Form constructor.
+    $form = parent::buildForm($form, $form_state);
+    // Default settings.
+    $config = $this->config('nlc_prototype.config_covid19.settings');
+
+    $form['covid19_survey_url'] = [
+      '#type' => 'url',
+      '#title' => $this->t('COVID-19 survey URL'),
+      '#size' => 64,
+      '#default_value' => $config->get('covid19.survey_url'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $config = $this->config('nlc_prototype.config_covid19.settings');
+    $config->set('covid19.survey_url', $form_state->getValue('covid19_survey_url'));
+    $config->save();
+    return parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'nlc_prototype.config_covid19.settings',
+    ];
+  }
+
+}

--- a/web/modules/custom/nlc_prototype/src/Plugin/Block/Covid19EsurvSurveyBlock.php
+++ b/web/modules/custom/nlc_prototype/src/Plugin/Block/Covid19EsurvSurveyBlock.php
@@ -24,6 +24,10 @@ class Covid19EsurvSurveyBlock extends BlockBase {
    * @return array
    */
   public function build() {
+    /** @var \Drupal\Core\Render\RendererInterface $renderer */
+    $renderer = \Drupal::service('renderer');
+    $config = \Drupal::config('nlc_prototype.config_covid19.settings');
+    $surveyUri = $config->get('covid19.survey_url') ?: 'https://www.smartsurvey.co.uk/s/CV19Response_060420/';
     $build = [];
     $build['#attributes'] = [
       'class' => [
@@ -33,7 +37,7 @@ class Covid19EsurvSurveyBlock extends BlockBase {
     ];
     $build['#prefix'] = '<div class="govuk-width-container">';
     $build['#suffix'] = '</div>';
-    $surveyUrl = Url::fromUri('https://www.smartsurvey.co.uk/s/CV19Response_060420/');
+    $surveyUrl = Url::fromUri($surveyUri);
     $surveyLink = Link::fromTextAndUrl($this->t('Complete survey'), $surveyUrl)->toRenderable();
     $surveyLink['#attributes'] = [
       'target' => '_blank',
@@ -66,6 +70,7 @@ class Covid19EsurvSurveyBlock extends BlockBase {
         'link' => $surveyLink,
       ],
     ];
+    $renderer->addCacheableDependency($build, $config);
 
     return $build;
   }


### PR DESCRIPTION
Creates a custom config form at `/admin/config/connect/covid19` (accessed by users with new permission 'administer connect covid19 config') to set the URI for the survey.

Uses the URI ^^ to set the href for the button in the COVID-19 block.

Adds [config_ignore](https://www.drupal.org/project/config_ignore) contrib module and sets the config from ^^ to be ignored from `drush cim` config import.

Clubhouse ticket: [ch3593]