### PR TITLE
Feature: improve connect login successes by also looking up profile emails [ch4329]

### DIFF
--- a/web/modules/custom/nlc_prototype/src/Form/DirectoryTokenAccessForm.php
+++ b/web/modules/custom/nlc_prototype/src/Form/DirectoryTokenAccessForm.php
@@ -129,7 +129,7 @@ class DirectoryTokenAccessForm extends FormBase {
     $email = $form_state->getValue('email');
     $account = $this->loadUserByAccountOrProfileEmail($email);
     $form_state->setValue('account', $account);
-    if (empty($account)) {
+    if (empty($account) || $account->isBlocked()) {
       $form_state->setErrorByName('email', $this->t('Check your email address.'));
       $email = 'NLC@CabinetOffice.gov.uk';
       $mailUrl = Url::fromUri('mailto:' . $email);

--- a/web/modules/custom/nlc_prototype/src/Form/DirectoryTokenAccessForm.php
+++ b/web/modules/custom/nlc_prototype/src/Form/DirectoryTokenAccessForm.php
@@ -264,7 +264,9 @@ class DirectoryTokenAccessForm extends FormBase {
     $account = user_load_by_mail($email);
     if (!$account) {
       $properties = [
-        ''
+        'type' => 'role',
+        'field_finish_date' => '',
+        'nlc_role_email' => $email,
       ];
       $account = \Drupal::entityTypeManager()
         ->getStorage('profile')

--- a/web/modules/custom/nlc_prototype/src/Form/DirectoryTokenAccessForm.php
+++ b/web/modules/custom/nlc_prototype/src/Form/DirectoryTokenAccessForm.php
@@ -122,8 +122,8 @@ class DirectoryTokenAccessForm extends FormBase {
    * {@inheritDoc}
    */
   public function validateForm(array &$form, FormStateInterface $form_state) {
-    /** @var \Drupal\user\Entity\User $account */
-    $account = user_load_by_mail($form_state->getValue('email'));
+    $email = $form_state->getValue('email');
+    $account = $this->loadUserByAccountOrProfileEmail($email);
     if (empty($account)) {
       $form_state->setErrorByName('email', $this->t('Check your email address.'));
       $email = 'NLC@CabinetOffice.gov.uk';
@@ -250,6 +250,27 @@ class DirectoryTokenAccessForm extends FormBase {
         ->getLanguage($langCode),
     ])
       ->toString();
+  }
+
+  /**
+   * Try to load a valid user account, using either the account email or a current profile email address.
+   *
+   * @param string $email
+   *
+   * @return \Drupal\user\Entity\User|bool
+   */
+  private function loadUserByAccountOrProfileEmail($email) {
+    /** @var \Drupal\user\Entity\User $account */
+    $account = user_load_by_mail($email);
+    if (!$account) {
+      $properties = [
+        ''
+      ];
+      $account = \Drupal::entityTypeManager()
+        ->getStorage('profile')
+        ->loadByProperties($properties);
+    }
+    return $account;
   }
 
 }

--- a/web/modules/custom/nlc_salesforce/src/SFAPI/SFWrapper.php
+++ b/web/modules/custom/nlc_salesforce/src/SFAPI/SFWrapper.php
@@ -53,6 +53,8 @@ class SFWrapper {
 
   /**
    * Salesforce client.
+   *
+   * @var \Drupal\salesforce\Rest\RestClient
    */
   private $client = NULL;
   /**
@@ -109,8 +111,10 @@ class SFWrapper {
   /**
    * Get a Salesforce object which matches the ID.
    *
-   * @param $sfIdValue The Salesforce id.
-   * @return SObject The Salesforce object
+   * @param $sfIdValue
+   *   The Salesforce id.
+   * @return \Drupal\salesforce\SObject
+   *   The Salesforce object.
    */
   public function getObject($sfId) {
     /* TODO: Add caching depending on $sfId */
@@ -136,8 +140,10 @@ class SFWrapper {
   /**
    * Get field values from the object with the passed ID.
    * 
-   * @param $sfIdValue The Salesforce id.
-   * @return [] Associatve array of field name and values from Salesforce.
+   * @param $sfIdValue
+   *   The Salesforce id.
+   * @return []
+   *   Associatve array of field name and values from Salesforce.
    */
   public function getDetails($sfId) {
     if ($obj = $this->getObject($sfId)) {
@@ -165,6 +171,10 @@ class SFWrapper {
    */
   public function getSubmissions() {
     return $this->submissions;
+  }
+
+  public function getSfProfileFromEmail() {
+
   }
 
 }


### PR DESCRIPTION
Previously we've only checked on the email address associated with the Connect user account, but users may have multiple email addresses, one for each separate role.

This update checks the Connect user account first. If the supplied email does not validate then it tries querying Salesforce for the email address in an active Network Individual Role object (i.e. does not have an 'end date' set), and if it is true and matches a profile in Connect, then load the user account for that profile and send the one-time URL login for that user account to the email address supplied.